### PR TITLE
Adds support for cyclic dependencies using a proxy. Updates documentation and logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,17 @@ public interface IMyEndpoint
 
 To create a `AuthenticationTokenHandler`, you provide an `IAuthenticationTokenProvider`.
 
+There is an implementation of `IAuthenticationTokenProvider` that receives the different delegates as parameters but you can create your own implementation.
+
 ```csharp
-var authenticationTokenProvider = new MyAuthenticationTokenProvider();
+var authenticationService = new AuthenticationService();
+
+var authenticationTokenProvider = new AuthenticationTokenProvider<MyAuthenticationToken>(
+  getToken: (ct, request) => authenticationService.GetToken(ct, request),
+  notifySessionExpired: (ct, request, token) => authenticationService.NotifySessionExpired(ct, request, token),
+  refreshToken: (ct, request, token) => authenticationService.RefreshToken(ct, request, token)  // Optional
+);
+
 var authenticationHandler = new AuthenticationTokenHandler<MyAuthenticationToken>(authenticationTokenProvider);
 
 public class MyAuthenticationToken : IAuthenticationToken
@@ -190,7 +199,7 @@ public class MyAuthenticationToken : IAuthenticationToken
   public bool CanBeRefreshed => RefreshToken != null; // Whether or not the access token can be refreshed.
 }
 
-public class MyAuthenticationTokenProvider : IAuthenticationTokenProvider<MyAuthenticationToken>
+public class MyAuthenticationService
 {
   public Task<MyAuthenticationToken> GetToken(CancellationToken ct, HttpRequestMessage request)
   {

--- a/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenProvider.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenProvider.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MallardMessageHandlers
+{
+	/// <summary>
+	/// This is a simple proxy for <see cref="IAuthenticationTokenProvider{TAuthenticationToken}"/>.
+	/// It helps break the circular dependency that might originate when implementing the interface.
+	/// - Service A uses Endpoint B.
+	/// - Endpoint B uses AuthenticationTokenHandler.
+	/// - AuthenticationTokenHandler uses IAuthenticationTokenProvider.
+	/// - IAuthenticationTokenProvider uses Service A.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">Type of authentication token</typeparam>
+	public class AuthenticationTokenProvider<TAuthenticationToken> : IAuthenticationTokenProvider<TAuthenticationToken>
+		where TAuthenticationToken : IAuthenticationToken
+	{
+		private readonly Func<CancellationToken, HttpRequestMessage, Task<TAuthenticationToken>> _getToken;
+		private readonly Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task> _notifySessionExpired;
+		private readonly Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task<TAuthenticationToken>> _refreshToken;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AuthenticationTokenProvider{TAuthenticationToken}"/> class.
+		/// </summary>
+		/// <param name="getToken">Method to retrieve the <typeparamref name="TAuthenticationToken"/>.</param>
+		/// <param name="notifySessionExpired">Method to call when the <typeparamref name="TAuthenticationToken"/> is considered expired.</param>
+		/// <param name="refreshToken">Method to refresh the token (only called if the token can be refreshed)</param>
+		public AuthenticationTokenProvider(
+			Func<CancellationToken, HttpRequestMessage, Task<TAuthenticationToken>> getToken,
+			Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task> notifySessionExpired,
+			Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task<TAuthenticationToken>> refreshToken = null
+		)
+		{
+			_getToken = getToken ?? throw new ArgumentNullException(nameof(getToken));
+			_notifySessionExpired = notifySessionExpired ?? throw new ArgumentNullException(nameof(notifySessionExpired));
+			_refreshToken = refreshToken;
+		}
+
+		/// <inheritdoc />
+		public Task<TAuthenticationToken> GetToken(CancellationToken ct, HttpRequestMessage request) =>
+			_getToken.Invoke(ct, request);
+
+		/// <inheritdoc />
+		public Task NotifySessionExpired(CancellationToken ct, HttpRequestMessage request, TAuthenticationToken unauthorizedToken) =>
+			_notifySessionExpired.Invoke(ct, request, unauthorizedToken);
+
+		/// <inheritdoc />
+		public async Task<TAuthenticationToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TAuthenticationToken unauthorizedToken)
+		{
+			if (_refreshToken == null)
+			{
+				throw new NotSupportedException("This authentication token provider doesn't support refreshing the token.");
+			}
+
+			return await _refreshToken.Invoke(ct, request, unauthorizedToken);
+		}
+	}
+}


### PR DESCRIPTION
## Proposed Changes
- Feature


## What is the current behavior?

Users might experience difficulties when implementing `IAuthenticationTokenProvider` as in most cases, its implementation was in a service which uses an endpoint which uses the handler which uses the provider. This is creating a circular dependency that might not be obvious to solve.

## What is the new behavior?

Simple implementation of `IAuthenticationTokenProvider` which receives the different delegates in parameters. This breaks the circular dependency issue at the constructor level.

- Updated documentation.
- Updated logs.
