### PR TITLE
Fix: Semaphore inside AuthenticationHandler was never released

### DIFF
--- a/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandler.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandler.cs
@@ -152,65 +152,63 @@ namespace MallardMessageHandlers
 			// Wait for the semaphore.
 			await _semaphore.WaitAsync(ct);
 
-			// From this moment, the operation cannot be cancelled.
-			var refreshedToken = await GetRefreshedAuthenticationToken(
-				CancellationToken.None,
-				request,
-				unauthorizedToken
-			);
-
-			// Release the semaphore.
-			_semaphore.Release();
-
-			return refreshedToken;
-		}
-
-		private async Task<TAuthenticationToken> GetRefreshedAuthenticationToken(
-			CancellationToken ct,
-			HttpRequestMessage request,
-			TAuthenticationToken unauthorizedToken)
-		{
-			// We get the current authentication token inside the lock
-			// as it's very possible that the unauthorized token is no
-			// longer the current token because another refresh request was made.
-			var currentToken = await _tokenProvider.GetToken(ct, request);
-
-			_logger.LogDebug($"The current token is: '{currentToken}'.");
-
-			// If we don't have an authentication data or a refresh token, we cannot refresh the access token.
-			// This can happen if the session has expired while 2 concurrent refresh requests were made.
-			// The second request will not have a refresh token.
-			if (currentToken == null || !currentToken.CanBeRefreshed)
-			{
-				_logger.LogWarning($"The refresh token is null or cannot be refreshed.");
-
-				return default;
-			}
-
-			// If we have an access token but it's not the same, the token has been refreshed.
-			if (currentToken.AccessToken != null &&
-				currentToken.AccessToken != unauthorizedToken.AccessToken)
-			{
-				_logger.LogWarning($"The access tokens are different. No need to refresh, returning the current token '{currentToken}'.");
-
-				return currentToken;
-			}
-
 			try
 			{
-				_logger.LogDebug($"Refreshing token: '{unauthorizedToken}'.");
-
-				var refreshedToken = await _tokenProvider.RefreshToken(ct, request, currentToken);
-
-				_logger.LogInformation($"Refreshed token: '{unauthorizedToken}' to '{refreshedToken}'.");
+				// From this moment, the operation cannot be cancelled.
+				var refreshedToken = await GetRefreshedAuthenticationToken(CancellationToken.None);
 
 				return refreshedToken;
 			}
-			catch (Exception e)
+			finally
 			{
-				_logger.LogError(e, $"Failed to refresh token: '{unauthorizedToken}'.");
+				// Release the semaphore.
+				_semaphore.Release();
+			}
 
-				return default;
+			async Task<TAuthenticationToken> GetRefreshedAuthenticationToken(CancellationToken ct2)
+			{
+				// We get the current authentication token inside the lock
+				// as it's very possible that the unauthorized token is no
+				// longer the current token because another refresh request was made.
+				var currentToken = await _tokenProvider.GetToken(ct2, request);
+
+				_logger.LogDebug($"The current token is: '{currentToken}'.");
+
+				// If we don't have an authentication data or a refresh token, we cannot refresh the access token.
+				// This can happen if the session has expired while 2 concurrent refresh requests were made.
+				// The second request will not have a refresh token.
+				if (currentToken == null || !currentToken.CanBeRefreshed)
+				{
+					_logger.LogWarning($"The refresh token is null or cannot be refreshed.");
+
+					return default;
+				}
+
+				// If we have an access token but it's not the same, the token has been refreshed.
+				if (currentToken.AccessToken != null &&
+					currentToken.AccessToken != unauthorizedToken.AccessToken)
+				{
+					_logger.LogWarning($"The access tokens are different. No need to refresh, returning the current token '{currentToken}'.");
+
+					return currentToken;
+				}
+
+				try
+				{
+					_logger.LogDebug($"Refreshing token: '{unauthorizedToken}'.");
+
+					var refreshedToken = await _tokenProvider.RefreshToken(ct2, request, currentToken);
+
+					_logger.LogInformation($"Refreshed token: '{unauthorizedToken}' to '{refreshedToken}'.");
+
+					return refreshedToken;
+				}
+				catch (Exception e)
+				{
+					_logger.LogError(e, $"Failed to refresh token: '{unauthorizedToken}'.");
+
+					return default;
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue: N/A

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
The AuthenticationHandler is able to handle unauthorized request only once while the app is opened, because the semaphore inside is never released

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The AuthenticationHandler is able to handle unauthorized request multple times while the app is opened.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated~~
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

