### PR TITLE
Fix 2 bugs related to AuthenticationTokenHandler (Refresh semaphore, NotifyExpiredSession)

### DIFF
--- a/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
+++ b/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
@@ -520,6 +520,139 @@ namespace MallardMessageHandlers.Tests
 			sessionExpired.Should().BeTrue();
 		}
 
+		[Fact]
+		public async Task It_Handle_MultipleUnauthorizedRequest()
+		{
+			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+			var refreshedAuthenticationToken = new TestToken("AccessToken2", "RefreshToken2");
+			var authorizationHeaders = new List<AuthenticationHeaderValue>();
+
+			var hasNotRefreshed = true;
+			TestToken currentRefreshToken = null;
+
+			async Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
+			{
+				await Task.Delay(50);
+				return hasNotRefreshed ? authenticationToken : currentRefreshToken;
+			}
+
+			Task SessionExpired(CancellationToken ct, HttpRequestMessage request, TestToken unauthorizedToken)
+				=> Task.CompletedTask;
+
+			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				currentRefreshToken = hasNotRefreshed ? refreshedAuthenticationToken : null;
+				hasNotRefreshed = false;
+				return Task.FromResult(currentRefreshToken);
+			}
+
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddTransient<AuthenticationTokenHandler<TestToken>>()
+				.AddTransient(_ => new TestHandler((r, ct) =>
+				{
+					authorizationHeaders.Add(r.Headers.Authorization);
+
+					var isUnauthorized = r.Headers.Authorization.Parameter != null && r.Headers.Authorization.Parameter == authenticationToken.AccessToken;
+
+					return Task.FromResult(new HttpResponseMessage(isUnauthorized ? HttpStatusCode.Unauthorized : HttpStatusCode.OK));
+				}));
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+
+			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+
+			// Simulate multiple unauthorized request.
+			await Task.WhenAll(
+				httpClient.GetAsync(DefaultRequestUri),
+				httpClient.GetAsync(DefaultRequestUri),
+				httpClient.GetAsync(DefaultRequestUri)
+			);
+
+			// Validate that there were 6 request in total 3 requests (unauthorized request + request with new token).
+			authorizationHeaders.Count.Should().Be(6);
+
+			for (var i = 0; i < 3; i++)
+			{
+				// Unauthorized request.
+				authorizationHeaders.ElementAt(i).Parameter.Should().Be(authenticationToken.AccessToken);
+
+				// request with new token.
+				authorizationHeaders.ElementAt(3 + i).Parameter.Should().Be(refreshedAuthenticationToken.AccessToken);
+			}
+		}
+
+		[Fact]
+		public async Task It_Handle_MultipleUnauthorizedRequest_With_DifferentEndpoints()
+		{
+			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+			var refreshedAuthenticationToken = new TestToken("AccessToken2", "RefreshToken2");
+			var authorizationHeaders = new List<AuthenticationHeaderValue>();
+
+			var hasNotRefreshed = true;
+			TestToken currentRefreshToken = null;
+
+			async Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
+			{
+				await Task.Delay(50);
+				return hasNotRefreshed ? authenticationToken : currentRefreshToken;
+			}
+
+			Task SessionExpired(CancellationToken ct, HttpRequestMessage request, TestToken unauthorizedToken)
+				=> Task.CompletedTask;
+
+			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				currentRefreshToken = hasNotRefreshed ? refreshedAuthenticationToken : null;
+				hasNotRefreshed = false;
+				return Task.FromResult(currentRefreshToken);
+			}
+
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddTransient<AuthenticationTokenHandler<TestToken>>()
+				.AddTransient(_ => new TestHandler((r, ct) =>
+				{
+					authorizationHeaders.Add(r.Headers.Authorization);
+
+					var isUnauthorized = r.Headers.Authorization.Parameter != null && r.Headers.Authorization.Parameter == authenticationToken.AccessToken;
+
+					return Task.FromResult(new HttpResponseMessage(isUnauthorized ? HttpStatusCode.Unauthorized : HttpStatusCode.OK));
+				}));
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+			var httpClient2 = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+
+			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+			httpClient2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+
+			// Simulate multiple unauthorized request.
+			await Task.WhenAll(
+				httpClient.GetAsync(DefaultRequestUri),
+				httpClient2.GetAsync(DefaultRequestUri)
+			);
+
+			// Validate that there were 2 request in total 2 requests (unauthorized request + request with new token).
+			authorizationHeaders.Count.Should().Be(4);
+
+			for (var i = 0; i < 2; i++)
+			{
+				// Unauthorized request.
+				authorizationHeaders.ElementAt(i).Parameter.Should().Be(authenticationToken.AccessToken);
+
+				// request with new token.
+				authorizationHeaders.ElementAt(2 + i).Parameter.Should().Be(refreshedAuthenticationToken.AccessToken);
+			}
+		}
+
 		public class AuthenticationClient
 		{
 			public AuthenticationClient(HttpClient client) { }

--- a/src/MallardMessageHandlers.Tests/Helpers/TestToken.cs
+++ b/src/MallardMessageHandlers.Tests/Helpers/TestToken.cs
@@ -9,16 +9,19 @@ namespace MallardMessageHandlers.Tests
 {
 	public class TestToken : IAuthenticationToken
 	{
-		public TestToken(string accessToken, string refreshToken = null)
+		public TestToken(string id, bool generateRefreshToken = false)
 		{
-			AccessToken = accessToken;
-			RefreshToken = refreshToken;
+			Id = id;
+			AccessToken = Guid.NewGuid().ToString().Substring(0, 10);
+			RefreshToken = generateRefreshToken ? Guid.NewGuid().ToString().Substring(0, 10) : string.Empty;
 		}
+
+		public string Id { get; set; }
 
 		public string AccessToken { get; set; }
 
 		public string RefreshToken { get; set; }
 
-		public bool CanBeRefreshed => RefreshToken != null;
+		public bool CanBeRefreshed => !string.IsNullOrEmpty(RefreshToken);
 	}
 }

--- a/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandler.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandler.cs
@@ -25,8 +25,9 @@ namespace MallardMessageHandlers
 	public class AuthenticationTokenHandler<TAuthenticationToken> : DelegatingHandler
 		where TAuthenticationToken : IAuthenticationToken
 	{
+		private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+
 		private readonly IAuthenticationTokenProvider<TAuthenticationToken> _tokenProvider;
-		private readonly SemaphoreSlim _semaphore;
 		private readonly ILogger _logger;
 
 		/// <summary>
@@ -41,7 +42,6 @@ namespace MallardMessageHandlers
 		{
 			_tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
 			_logger = logger ?? NullLogger<AuthenticationTokenHandler<TAuthenticationToken>>.Instance;
-			_semaphore = new SemaphoreSlim(1);
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
GitHub Issue:

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
- When multiple concurrent request are unauthorized, one of the request will automatically logged out the user, 
- When multiple concurrent request has its session expired, it triggers NotifySessionExpired multiple times.

## What is the new behavior?
- When multiple concurrent request are unauthorized, we make sure that the first request refresh the authenticationtoken and the other one use the refreshed token.
- When multiple concurrent request has its session expired, it triggers NotifySessionExpired only once per TAuthenticationToken.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated~~
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

