### PR TITLE
Add AuthenticationTokenHandlerContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ You would generally register the `AuthenticationTokenHandler` on your `IServiceP
 ```csharp
 private void ConfigureAuthenticationTokenHandler(IServiceCollection services)
 {
+  // The AuthenticationTokenHandlerContext must be shared for all HttpRequests, so we add it as singleton.
+  services.AddSingleton<AuthenticationTokenHandlerContext>();
+
   // The AuthenticationTokenProvider must be shared for all HttpRequests so we add it as singleton.
   services.AddSingleton<IAuthenticationTokenProvider<MyAuthenticationToken>, MyAuthenticationTokenProvider>();
 

--- a/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
+++ b/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
@@ -633,16 +633,15 @@ namespace MallardMessageHandlers.Tests
 				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
 				.AddHttpMessageHandler<TestHandler>();
 
-			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
-			var httpClient2 = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+			var httpClients = HttpClientTestsHelper.GetTestHttpClients(BuildServices, BuildHttpClient);
 
-			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
-			httpClient2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+			httpClients.client1.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+			httpClients.client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
 
 			// Simulate multiple unauthorized request.
 			await Task.WhenAll(
-				httpClient.GetAsync(DefaultRequestUri),
-				httpClient2.GetAsync(DefaultRequestUri)
+				httpClients.client1.GetAsync(DefaultRequestUri),
+				httpClients.client2.GetAsync(DefaultRequestUri)
 			);
 
 			// Validate that there were 2 request in total 2 requests (unauthorized request + request with new token).
@@ -744,15 +743,14 @@ namespace MallardMessageHandlers.Tests
 				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
 				.AddHttpMessageHandler<TestHandler>();
 
-			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
-			var httpClient2 = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+			var httpClients = HttpClientTestsHelper.GetTestHttpClients(BuildServices, BuildHttpClient);
 
-			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
-			httpClient2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+			httpClients.client1.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+			httpClients.client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
 
 			await Task.WhenAll(
-				httpClient.GetAsync(DefaultRequestUri),
-				httpClient2.GetAsync(DefaultRequestUri)
+				httpClients.client1.GetAsync(DefaultRequestUri),
+				httpClients.client2.GetAsync(DefaultRequestUri)
 			);
 
 			refreshedToken.Should().BeTrue();

--- a/src/MallardMessageHandlers.Tests/Helpers/HttpClientTestsHelper.cs
+++ b/src/MallardMessageHandlers.Tests/Helpers/HttpClientTestsHelper.cs
@@ -9,6 +9,7 @@ namespace MallardMessageHandlers.Tests
 	public static class HttpClientTestsHelper
 	{
 		private const string TestHttpClientName = nameof(TestHttpClientName);
+		private const string TestHttpClientName2 = nameof(TestHttpClientName2);
 
 		public static IHttpClientFactory GetHttpClientFactory(Action<ServiceCollection> serviceCollectionBuilder)
 		{
@@ -39,6 +40,22 @@ namespace MallardMessageHandlers.Tests
 			});
 
 			return httpClientFactory.CreateClient(TestHttpClientName);
+		}
+
+		public static (HttpClient client1, HttpClient client2) GetTestHttpClients(
+			Action<ServiceCollection> serviceCollectionBuilder,
+			Action<IHttpClientBuilder> httpClientBuilder
+		)
+		{
+			var httpClientFactory = GetHttpClientFactory(s =>
+			{
+				serviceCollectionBuilder(s);
+
+				httpClientBuilder(s.AddHttpClient(TestHttpClientName));
+				httpClientBuilder(s.AddHttpClient(TestHttpClientName2));
+			});
+
+			return (httpClientFactory.CreateClient(TestHttpClientName), httpClientFactory.CreateClient(TestHttpClientName2));
 		}
 
 		public static HttpResponseMessage CreateHttpResponseMessage(TestResponse response, HttpStatusCode statusCode)

--- a/src/MallardMessageHandlers.Tests/Helpers/TestToken.cs
+++ b/src/MallardMessageHandlers.Tests/Helpers/TestToken.cs
@@ -14,11 +14,10 @@ namespace MallardMessageHandlers.Tests
 			AccessToken = accessToken;
 			RefreshToken = refreshToken;
 		}
-
 		public string AccessToken { get; set; }
 
 		public string RefreshToken { get; set; }
 
-		public bool CanBeRefreshed => RefreshToken != null;
+		public bool CanBeRefreshed => !string.IsNullOrEmpty(RefreshToken);
 	}
 }

--- a/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandler.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandler.cs
@@ -72,7 +72,7 @@ namespace MallardMessageHandlers
 				_logger.LogError($"The request '{request.RequestUri}' was unauthorized and the token '{token}' cannot be refreshed. Considering the session has expired.");
 
 				// Request was unauthorized and we cannot refresh the authentication token.
-				await NotifySessionExpired(ct, request, token);
+				await TryNotifySessionExpired(ct, request, token);
 
 				return response;
 			}
@@ -84,7 +84,7 @@ namespace MallardMessageHandlers
 				_logger.LogError($"The request '{request.RequestUri}' was unauthorized and the token '{token}' could not be refreshed. Considering the session has expired.");
 
 				// No authentication token to use.
-				await NotifySessionExpired(ct, request, token);
+				await TryNotifySessionExpired(ct, request, token);
 
 				return response;
 			}
@@ -96,14 +96,14 @@ namespace MallardMessageHandlers
 				_logger.LogError($"The request '{request.RequestUri}' was unauthorized, the token '{token}' was refreshed to '{refreshedToken}' but the request was still unauthorized. Considering the session has expired.");
 
 				// Request was still unauthorized and we cannot refresh the authentication token.
-				await NotifySessionExpired(ct, request, refreshedToken);
+				await TryNotifySessionExpired(ct, request, refreshedToken);
 
 				return response;
 			}
 
 			return response;
 
-			async Task NotifySessionExpired(CancellationToken ct2, HttpRequestMessage innerRequest, TAuthenticationToken innerToken)
+			async Task TryNotifySessionExpired(CancellationToken ct2, HttpRequestMessage innerRequest, TAuthenticationToken innerToken)
 			{
 				// Make sure that we notify that the session has been expired only once per TAutenticationToken.
 				if (!innerToken.AccessToken.Equals(_context.LastExpiredToken))

--- a/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandlerContext.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandlerContext.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace MallardMessageHandlers
+{
+	public class AuthenticationTokenHandlerContext
+	{
+		public AuthenticationTokenHandlerContext()
+		{
+			RefreshSemaphore = new SemaphoreSlim(1);
+		}
+
+		public SemaphoreSlim RefreshSemaphore { get; private set; }
+
+		public string LastExpiredToken { get; set; }
+	}
+}

--- a/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandlerContext.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenHandlerContext.cs
@@ -5,6 +5,16 @@ using System.Threading;
 
 namespace MallardMessageHandlers
 {
+	/// <summary>
+	/// This represents the context for a <see cref="AuthenticationTokenHandler{TAuthenticationToken}"/>.
+	/// It's use mostly to help <see cref="AuthenticationTokenHandler{TAuthenticationToken}"/> handles thoses actions:
+	/// - Refreshing the token when expired.
+	/// - Detecting an expiration session.
+	/// By default, each <see cref="AuthenticationTokenHandler{TAuthenticationToken}"/> has its own context.
+	/// However, if there's multiple <see cref="AuthenticationTokenHandler{TAuthenticationToken}"/> (e.g. multiple endpoints),
+	/// it's strongly recommended that they're all shared the same context,
+	/// otherwise there's going to be synchronization issues when one of the endpoint either refresh the TAuthenticationToken or signal an expired session.
+	/// </summary>
 	public class AuthenticationTokenHandlerContext
 	{
 		public AuthenticationTokenHandlerContext()
@@ -14,6 +24,6 @@ namespace MallardMessageHandlers
 
 		public SemaphoreSlim RefreshSemaphore { get; private set; }
 
-		public string LastExpiredToken { get; set; }
+		public string LastExpiredToken { get; internal set; }
 	}
 }


### PR DESCRIPTION
## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->

## What is the current behavior?
- When multiple concurrent request are unauthorized, one of the request will automatically logged out the user, 
- When multiple concurrent request has its session expired, it triggers NotifySessionExpired multiple times.

## What is the new behavior?
- When multiple concurrent request are unauthorized, we make sure that the first request refresh the authenticationtoken and the other one use the refreshed token.
- When multiple concurrent request has its session expired, it triggers NotifySessionExpired only once per TAuthenticationToken.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the Changelog~~ <-- Should this be something we do for this project, since it seems to be empty at the moment
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
We've found a more optimal solution that started from this PR #45 

