### PR TITLE
feat: add ConcurrentAuthenticationTokenProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ There is an implementation of `IAuthenticationTokenProvider` that receives the d
 ```csharp
 var authenticationService = new AuthenticationService();
 
-var authenticationTokenProvider = new AuthenticationTokenProvider<MyAuthenticationToken>(
+var authenticationTokenProvider = new ConcurrentAuthenticationTokenProvider<MyAuthenticationToken>(
+  loggerFactory: null,
   getToken: (ct, request) => authenticationService.GetToken(ct, request),
   notifySessionExpired: (ct, request, token) => authenticationService.NotifySessionExpired(ct, request, token),
   refreshToken: (ct, request, token) => authenticationService.RefreshToken(ct, request, token)  // Optional

--- a/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
+++ b/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using MallardMessageHandlers;
 using Xunit;
+using Microsoft.Extensions.Logging;
 
 namespace MallardMessageHandlers.Tests
 {
@@ -31,7 +32,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.CompletedTask;
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -65,7 +66,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.CompletedTask;
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -104,7 +105,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.CompletedTask;
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage())));
 
@@ -140,7 +141,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage())));
 
@@ -174,7 +175,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.FromResult(refreshedAuthenticationToken);
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -217,7 +218,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, notifySessionExpired: SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -259,7 +260,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -299,7 +300,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -349,7 +350,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -372,12 +373,13 @@ namespace MallardMessageHandlers.Tests
 		{
 			// The following circular reference is tested here:
 			// AuthenticationTokenHandler -> IAuthenticationTokenProvider
-			// AuthenticationTokenProvider -> AuthenticationClient
+			// IAuthenticationTokenProvider -> AuthenticationClient
 			// AuthenticationClient -> AuthenticationTokenHandler
 
 			void BuildServices(IServiceCollection s) => s
 				// IAuthenticationTokenProvider is AuthenticationTokenProvider which depends on AuthenticationClient
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new AuthenticationTokenProvider<TestToken>(
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(
+					sp.GetService<ILoggerFactory>(),
 					(ct, r) => sp.GetRequiredService<AuthenticationClient>().GetToken(ct, r),
 					(ct, r, t) => Task.CompletedTask
 				))
@@ -408,15 +410,17 @@ namespace MallardMessageHandlers.Tests
 		public async Task It_NotifiesSessionExpired_If_Refreshed_And_Unauthorized_MultipeTimes()
 		{
 			var sessionExpired = false;
-			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
-			var refreshedAuthenticationToken = new TestToken("AccessToken2", "RefreshToken2");
+			var IsFirstRequestDone = false;
+
+			var firstAuthenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+			var secondAuthenticationToken = new TestToken("AccessToken2", "RefreshToken2");
 			var authorizationHeaders = new List<AuthenticationHeaderValue>();
 
 			Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
-				=> Task.FromResult(authenticationToken);
+				=> Task.FromResult(IsFirstRequestDone ? secondAuthenticationToken : firstAuthenticationToken);
 
 			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
-				=> Task.FromResult(refreshedAuthenticationToken);
+				=> Task.FromResult(default(TestToken));
 
 			Task SessionExpired(CancellationToken ct, HttpRequestMessage request, TestToken token)
 			{
@@ -426,15 +430,13 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
 					authorizationHeaders.Add(r.Headers.Authorization);
 
-					var isUnauthorized = r.Headers.Authorization.Parameter == authenticationToken.AccessToken;
-
-					return Task.FromResult(new HttpResponseMessage(isUnauthorized ? HttpStatusCode.Unauthorized : HttpStatusCode.Unauthorized));
+					return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized));
 				}));
 
 			void BuildHttpClient(IHttpClientBuilder h) => h
@@ -449,10 +451,11 @@ namespace MallardMessageHandlers.Tests
 			// First time execute Get with unauthorized authentication token.
 			await httpClient.GetAsync(DefaultRequestUri);
 
-			authorizationHeaders.Count.Should().Be(2);
+			authorizationHeaders.Count.Should().Be(1);
 			sessionExpired.Should().BeTrue();
 
 			// Second time logged in.
+			IsFirstRequestDone = true;
 			sessionExpired = false;
 			authorizationHeaders.Clear();
 			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
@@ -460,7 +463,7 @@ namespace MallardMessageHandlers.Tests
 			// Second time execute Get with unauthorized authentication token.
 			await httpClient.GetAsync(DefaultRequestUri);
 
-			authorizationHeaders.Count.Should().Be(2);
+			authorizationHeaders.Count.Should().Be(1);
 			sessionExpired.Should().BeTrue();
 		}
 
@@ -469,10 +472,13 @@ namespace MallardMessageHandlers.Tests
 		{
 			var sessionExpired = false;
 			var refreshedToken = false;
-			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+			var IsFirstRequestDone = false;
+
+			var firstAuthenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+			var secondAuthenticationToken = new TestToken("AccessToken2", "RefreshToken2");
 
 			Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
-				=> Task.FromResult(authenticationToken);
+				=> Task.FromResult(IsFirstRequestDone ? secondAuthenticationToken : firstAuthenticationToken);
 
 			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
 			{
@@ -489,7 +495,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(new AuthenticationTokenProvider<TestToken>(GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -510,6 +516,7 @@ namespace MallardMessageHandlers.Tests
 
 			// Second time logged in.
 			sessionExpired = false;
+			IsFirstRequestDone = true;
 			refreshedToken = false;
 			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
 
@@ -518,6 +525,237 @@ namespace MallardMessageHandlers.Tests
 
 			refreshedToken.Should().BeTrue();
 			sessionExpired.Should().BeTrue();
+		}
+
+		[Fact]
+		public async Task It_Handle_MultipleUnauthorizedRequest()
+		{
+			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+			var refreshedAuthenticationToken = new TestToken("AccessToken2", "RefreshToken2");
+			var authorizationHeaders = new List<AuthenticationHeaderValue>();
+
+			var hasNotRefreshed = true;
+			TestToken currentRefreshToken = null;
+
+			async Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
+			{
+				await Task.Delay(50);
+				return hasNotRefreshed ? authenticationToken : currentRefreshToken;
+			}
+
+			Task SessionExpired(CancellationToken ct, HttpRequestMessage request, TestToken unauthorizedToken)
+				=> Task.CompletedTask;
+
+			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				currentRefreshToken = hasNotRefreshed ? refreshedAuthenticationToken : null;
+				hasNotRefreshed = false;
+				return Task.FromResult(currentRefreshToken);
+			}
+
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddTransient<AuthenticationTokenHandler<TestToken>>()
+				.AddTransient(_ => new TestHandler((r, ct) =>
+				{
+					authorizationHeaders.Add(r.Headers.Authorization);
+
+					var isUnauthorized = r.Headers.Authorization.Parameter != null && r.Headers.Authorization.Parameter == authenticationToken.AccessToken;
+
+					return Task.FromResult(new HttpResponseMessage(isUnauthorized ? HttpStatusCode.Unauthorized : HttpStatusCode.OK));
+				}));
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+
+			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+
+			// Simulate multiple unauthorized request.
+			await Task.WhenAll(
+				httpClient.GetAsync(DefaultRequestUri),
+				httpClient.GetAsync(DefaultRequestUri),
+				httpClient.GetAsync(DefaultRequestUri)
+			);
+
+			// Validate that there were 6 request in total 3 requests (unauthorized request + request with new token).
+			authorizationHeaders.Count.Should().Be(6);
+			for (var i = 0; i < 3; i++)
+			{
+				// Unauthorized request. (First three requests)
+				authorizationHeaders.ElementAt(i).Parameter.Should().Be(authenticationToken.AccessToken);
+
+				// request with new token. (Last three request, after one of the first three requets has succesfully refreshed its token)
+				authorizationHeaders.ElementAt(3 + i).Parameter.Should().Be(refreshedAuthenticationToken.AccessToken);
+			}
+		}
+
+		[Fact]
+		public async Task It_Handle_MultipleUnauthorizedRequest_With_DifferentEndpoints()
+		{
+			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+			var refreshedAuthenticationToken = new TestToken("AccessToken2", "RefreshToken2");
+			var authorizationHeaders = new List<AuthenticationHeaderValue>();
+
+			var hasNotRefreshed = true;
+			TestToken currentRefreshToken = null;
+
+			async Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
+			{
+				await Task.Delay(50);
+				return hasNotRefreshed ? authenticationToken : currentRefreshToken;
+			}
+
+			Task SessionExpired(CancellationToken ct, HttpRequestMessage request, TestToken unauthorizedToken)
+				=> Task.CompletedTask;
+
+			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				currentRefreshToken = hasNotRefreshed ? refreshedAuthenticationToken : null;
+				hasNotRefreshed = false;
+				return Task.FromResult(currentRefreshToken);
+			}
+
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddTransient<AuthenticationTokenHandler<TestToken>>()
+				.AddTransient(_ => new TestHandler((r, ct) =>
+				{
+					authorizationHeaders.Add(r.Headers.Authorization);
+
+					var isUnauthorized = r.Headers.Authorization.Parameter != null && r.Headers.Authorization.Parameter == authenticationToken.AccessToken;
+
+					return Task.FromResult(new HttpResponseMessage(isUnauthorized ? HttpStatusCode.Unauthorized : HttpStatusCode.OK));
+				}));
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClients = HttpClientTestsHelper.GetTestHttpClients(BuildServices, BuildHttpClient);
+
+			httpClients.client1.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+			httpClients.client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+
+			// Simulate multiple unauthorized request.
+			await Task.WhenAll(
+				httpClients.client1.GetAsync(DefaultRequestUri),
+				httpClients.client2.GetAsync(DefaultRequestUri)
+			);
+
+			// Validate that there were 2 request in total 2 requests (unauthorized request + request with new token).
+			authorizationHeaders.Count.Should().Be(4);
+			for (var i = 0; i < 2; i++)
+			{
+				// Unauthorized request. (First two requests)
+				authorizationHeaders.ElementAt(i).Parameter.Should().Be(authenticationToken.AccessToken);
+
+				// request with new token. (Last two request, after one of the first two requests has succesfully refreshed its token)
+				authorizationHeaders.ElementAt(2 + i).Parameter.Should().Be(refreshedAuthenticationToken.AccessToken);
+			}
+		}
+
+		[Fact]
+		public async Task It_NotifiesSessionExpiredOnce_If_Refresh_Throws_MultipleTimesConcurrently()
+		{
+			var sessionExpired = false;
+			var refreshedToken = false;
+			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+
+			var sessionExpiredCount = 0;
+
+			Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
+				=> Task.FromResult(authenticationToken);
+
+			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				refreshedToken = true;
+
+				throw new TestException();
+			}
+
+			Task SessionExpired(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				sessionExpired = true;
+				sessionExpiredCount++;
+
+				return Task.CompletedTask;
+			}
+
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddTransient<AuthenticationTokenHandler<TestToken>>()
+				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+
+			httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+
+			await Task.WhenAll(
+				httpClient.GetAsync(DefaultRequestUri),
+				httpClient.GetAsync(DefaultRequestUri)
+			);
+
+			refreshedToken.Should().BeTrue();
+			sessionExpired.Should().BeTrue();
+			sessionExpiredCount.Should().Be(1);
+		}
+
+		[Fact]
+		public async Task It_NotifiesSessionExpiredOnce_If_Refresh_Throws_MultipleTimesConcurrently_With_DifferentEndpoints()
+		{
+			var sessionExpired = false;
+			var refreshedToken = false;
+			var authenticationToken = new TestToken("AccessToken1", "RefreshToken1");
+
+			var sessionExpiredCount = 0;
+
+			Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
+				=> Task.FromResult(authenticationToken);
+
+			Task<TestToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				refreshedToken = true;
+
+				throw new TestException();
+			}
+
+			Task SessionExpired(CancellationToken ct, HttpRequestMessage request, TestToken token)
+			{
+				sessionExpired = true;
+				sessionExpiredCount++;
+
+				return Task.CompletedTask;
+			}
+
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddTransient<AuthenticationTokenHandler<TestToken>>()
+				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler<AuthenticationTokenHandler<TestToken>>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClients = HttpClientTestsHelper.GetTestHttpClients(BuildServices, BuildHttpClient);
+
+			httpClients.client1.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+			httpClients.client2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer");
+
+			await Task.WhenAll(
+				httpClients.client1.GetAsync(DefaultRequestUri),
+				httpClients.client2.GetAsync(DefaultRequestUri)
+			);
+
+			refreshedToken.Should().BeTrue();
+			sessionExpired.Should().BeTrue();
+			sessionExpiredCount.Should().Be(1);
 		}
 
 		public class AuthenticationClient

--- a/src/MallardMessageHandlers.Tests/Helpers/HttpClientTestsHelper.cs
+++ b/src/MallardMessageHandlers.Tests/Helpers/HttpClientTestsHelper.cs
@@ -9,6 +9,7 @@ namespace MallardMessageHandlers.Tests
 	public static class HttpClientTestsHelper
 	{
 		private const string TestHttpClientName = nameof(TestHttpClientName);
+		private const string TestHttpClientName2 = nameof(TestHttpClientName2);
 
 		public static IHttpClientFactory GetHttpClientFactory(Action<ServiceCollection> serviceCollectionBuilder)
 		{
@@ -39,6 +40,22 @@ namespace MallardMessageHandlers.Tests
 			});
 
 			return httpClientFactory.CreateClient(TestHttpClientName);
+		}
+
+		public static (HttpClient client1, HttpClient client2) GetTestHttpClients(
+			Action<ServiceCollection> serviceCollectionBuilder,
+			Action<IHttpClientBuilder> httpClientBuilder
+		)
+		{
+			var httpClientFactory = GetHttpClientFactory(s =>
+			{
+				serviceCollectionBuilder(s);
+
+				httpClientBuilder(s.AddHttpClient(TestHttpClientName));
+				httpClientBuilder(s.AddHttpClient(TestHttpClientName2));
+			});
+
+			return (httpClientFactory.CreateClient(TestHttpClientName), httpClientFactory.CreateClient(TestHttpClientName2));
 		}
 
 		public static HttpResponseMessage CreateHttpResponseMessage(TestResponse response, HttpStatusCode statusCode)

--- a/src/MallardMessageHandlers.Tests/Helpers/TestToken.cs
+++ b/src/MallardMessageHandlers.Tests/Helpers/TestToken.cs
@@ -14,11 +14,10 @@ namespace MallardMessageHandlers.Tests
 			AccessToken = accessToken;
 			RefreshToken = refreshToken;
 		}
-
 		public string AccessToken { get; set; }
 
 		public string RefreshToken { get; set; }
 
-		public bool CanBeRefreshed => RefreshToken != null;
+		public bool CanBeRefreshed => !string.IsNullOrEmpty(RefreshToken);
 	}
 }

--- a/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenProvider.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/AuthenticationTokenProvider.cs
@@ -16,6 +16,7 @@ namespace MallardMessageHandlers
 	/// - IAuthenticationTokenProvider uses Service A.
 	/// </summary>
 	/// <typeparam name="TAuthenticationToken">Type of authentication token</typeparam>
+	[Obsolete("AuthenticationTokenProvider is obsolete. Use ConcurrentAuthenticationTokenProvider instead.", error: true)]
 	public class AuthenticationTokenProvider<TAuthenticationToken> : IAuthenticationTokenProvider<TAuthenticationToken>
 		where TAuthenticationToken : IAuthenticationToken
 	{
@@ -29,6 +30,7 @@ namespace MallardMessageHandlers
 		/// <param name="getToken">Method to retrieve the <typeparamref name="TAuthenticationToken"/>.</param>
 		/// <param name="notifySessionExpired">Method to call when the <typeparamref name="TAuthenticationToken"/> is considered expired.</param>
 		/// <param name="refreshToken">Method to refresh the token (only called if the token can be refreshed)</param>
+		[Obsolete("AuthenticationTokenProvider is obsolete. Use ConcurrentAuthenticationTokenProvider instead.", error: true)]
 		public AuthenticationTokenProvider(
 			Func<CancellationToken, HttpRequestMessage, Task<TAuthenticationToken>> getToken,
 			Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task> notifySessionExpired,

--- a/src/MallardMessageHandlers/AuthenticationToken/ConcurrentAuthenticationTokenProvider.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/ConcurrentAuthenticationTokenProvider.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MallardMessageHandlers
+{
+	/// <summary>
+	/// This proxy ensures that only 1 RefreshToken operation runs a any time.
+	/// It also ensures that only 1 NotifySessionExpired operation runs for equivalent expirations.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">Type of authentication token</typeparam>
+	public class ConcurrentAuthenticationTokenProvider<TAuthenticationToken> : IAuthenticationTokenProvider<TAuthenticationToken>
+		where TAuthenticationToken : IAuthenticationToken
+	{
+		private readonly Func<CancellationToken, HttpRequestMessage, Task<TAuthenticationToken>> _getToken;
+		private readonly Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task> _notifySessionExpired;
+		private readonly Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task<TAuthenticationToken>> _refreshToken;
+
+		private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+		private readonly ILogger _logger;
+
+		private TAuthenticationToken _lastUnauthorizedToken;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ConcurrentAuthenticationTokenProvider{TAuthenticationToken}"/> class.
+		/// </summary>
+		/// <param name="loggerFactory">The logger factory to create the internal logger for this class.</param>
+		/// <param name="getToken">Method to retrieve the <typeparamref name="TAuthenticationToken"/>.</param>
+		/// <param name="notifySessionExpired">Method to call when the <typeparamref name="TAuthenticationToken"/> is considered expired.</param>
+		/// <param name="refreshToken">Method to refresh the token (only called if the token can be refreshed)</param>
+		public ConcurrentAuthenticationTokenProvider(
+			ILoggerFactory loggerFactory,
+			Func<CancellationToken, HttpRequestMessage, Task<TAuthenticationToken>> getToken,
+			Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task> notifySessionExpired,
+			Func<CancellationToken, HttpRequestMessage, TAuthenticationToken, Task<TAuthenticationToken>> refreshToken = null
+		)
+		{
+			_logger = loggerFactory?.CreateLogger<ConcurrentAuthenticationTokenProvider<TAuthenticationToken>>() ?? NullLogger<ConcurrentAuthenticationTokenProvider<TAuthenticationToken>>.Instance;
+			_getToken = getToken ?? throw new ArgumentNullException(nameof(getToken));
+			_notifySessionExpired = notifySessionExpired ?? throw new ArgumentNullException(nameof(notifySessionExpired));
+			_refreshToken = refreshToken;
+		}
+
+		/// <inheritdoc />
+		public Task<TAuthenticationToken> GetToken(CancellationToken ct, HttpRequestMessage request) =>
+			_getToken.Invoke(ct, request);
+
+		/// <inheritdoc />
+		public async Task NotifySessionExpired(CancellationToken ct, HttpRequestMessage request, TAuthenticationToken unauthorizedToken)
+		{
+			// Avoid notifiying more than once for the same token expiration.
+			if (_lastUnauthorizedToken?.AccessToken != unauthorizedToken?.AccessToken)
+			{
+				_lastUnauthorizedToken = unauthorizedToken;
+				await _notifySessionExpired(ct, request, unauthorizedToken);
+			}
+		}
+
+		/// <inheritdoc />
+		public async Task<TAuthenticationToken> RefreshToken(CancellationToken ct, HttpRequestMessage request, TAuthenticationToken unauthorizedToken)
+		{
+			if (_refreshToken == null)
+			{
+				throw new NotSupportedException("This authentication token provider doesn't support refreshing the token.");
+			}
+
+			// Wait for other refresh operations to finish.
+			await _semaphore.WaitAsync(ct);
+
+			try
+			{
+				// From this moment, the operation cannot be cancelled.
+				var refreshedToken = await GetRefreshedAuthenticationToken(CancellationToken.None);
+
+				return refreshedToken;
+			}
+			finally
+			{
+				// Release the semaphore.
+				_semaphore.Release();
+			}
+
+			async Task<TAuthenticationToken> GetRefreshedAuthenticationToken(CancellationToken ct2)
+			{
+				// We get the current authentication token inside the lock
+				// as it's very possible that the unauthorized token is no
+				// longer the current token because another refresh request was made.
+				var currentToken = await GetToken(ct2, request);
+
+				_logger.LogDebug($"The current token is: '{currentToken}'.");
+
+				// If we don't have an authentication data or a refresh token, we cannot refresh the access token.
+				// This can happen if the session has expired while 2 concurrent refresh requests were made.
+				// The second request will not have a refresh token.
+				if (currentToken == null || !currentToken.CanBeRefreshed)
+				{
+					_logger.LogWarning($"The refresh token is null or cannot be refreshed.");
+
+					return default;
+				}
+
+				// If we have an access token but it's not the same, the token has been refreshed.
+				if (currentToken.AccessToken != null &&
+					currentToken.AccessToken != unauthorizedToken.AccessToken)
+				{
+					_logger.LogWarning($"The access tokens are different. No need to refresh, returning the current token '{currentToken}'.");
+
+					return currentToken;
+				}
+
+				try
+				{
+					_logger.LogDebug($"Refreshing token: '{unauthorizedToken}'.");
+
+					var refreshedToken = await _refreshToken(ct2, request, currentToken);
+
+					_logger.LogInformation($"Refreshed token: '{unauthorizedToken}' to '{refreshedToken}'.");
+
+					return refreshedToken;
+				}
+				catch (Exception e)
+				{
+					_logger.LogError(e, $"Failed to refresh token: '{unauthorizedToken}'.");
+
+					return default;
+				}
+			}
+		}
+	}
+}

--- a/src/MallardMessageHandlers/AuthenticationToken/IAuthenticationTokenProvider.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/IAuthenticationTokenProvider.cs
@@ -7,6 +7,12 @@ using System.Threading.Tasks;
 
 namespace MallardMessageHandlers
 {
+	/// <summary>
+	/// An <see cref="IAuthenticationTokenProvider{TAuthenticationToken}"/> owns the authentication token.
+	/// Typically that would be your application's AuthenticationService.
+	/// We strongly suggest you use <see cref="ConcurrentAuthenticationTokenProvider{TAuthenticationToken}"/> so that you don't need to deal with concurrency handling in your application code.
+	/// </summary>
+	/// <typeparam name="TAuthenticationToken">The type of authentication token.</typeparam>
 	public interface IAuthenticationTokenProvider<TAuthenticationToken>
 		where TAuthenticationToken : IAuthenticationToken
 	{


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

The semaphor used in AuthenticationTokenHandler is not shared by all instances. This allows the RefreshToken operation to run concurrently.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

AuthenticationTokenHandler is no longer responsible for the concurrency issues around the RefreshToken operation.
A new class `ConcurrentAuthenticationTokenProvider` is introduced to deal with this.
`AuthenticationTokenProvider` is now obsolete.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

