### PR TITLE
Makes ConcurrentAuthenticationTokenProvider<TAuthenticationToken> abstract

### DIFF
--- a/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
+++ b/src/MallardMessageHandlers.Tests/AuthenticationTokenHandlerTests.cs
@@ -4,14 +4,12 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using MallardMessageHandlers;
-using Xunit;
 using Microsoft.Extensions.Logging;
+using Xunit;
 
 namespace MallardMessageHandlers.Tests
 {
@@ -32,7 +30,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.CompletedTask;
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -66,7 +64,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.CompletedTask;
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -105,7 +103,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.CompletedTask;
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage())));
 
@@ -141,7 +139,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage())));
 
@@ -175,7 +173,7 @@ namespace MallardMessageHandlers.Tests
 				=> Task.FromResult(refreshedAuthenticationToken);
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -218,7 +216,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -260,7 +258,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -300,7 +298,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -350,7 +348,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -378,7 +376,7 @@ namespace MallardMessageHandlers.Tests
 
 			void BuildServices(IServiceCollection s) => s
 				// IAuthenticationTokenProvider is AuthenticationTokenProvider which depends on AuthenticationClient
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(
 					sp.GetService<ILoggerFactory>(),
 					(ct, r) => sp.GetRequiredService<AuthenticationClient>().GetToken(ct, r),
 					(ct, r, t) => Task.CompletedTask
@@ -430,7 +428,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -495,7 +493,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -554,7 +552,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -619,7 +617,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) =>
 				{
@@ -685,7 +683,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -735,7 +733,7 @@ namespace MallardMessageHandlers.Tests
 			}
 
 			void BuildServices(IServiceCollection s) => s
-				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new ConcurrentAuthenticationTokenProvider<TestToken>(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
+				.AddSingleton<IAuthenticationTokenProvider<TestToken>>(sp => new DelegateAuthenticationTokenProvider(sp.GetService<ILoggerFactory>(), GetToken, SessionExpired, RefreshToken))
 				.AddTransient<AuthenticationTokenHandler<TestToken>>()
 				.AddTransient(_ => new TestHandler((r, ct) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized))));
 
@@ -763,6 +761,34 @@ namespace MallardMessageHandlers.Tests
 			public AuthenticationClient(HttpClient client) { }
 
 			public async Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request) => default(TestToken);
+		}
+
+		public class DelegateAuthenticationTokenProvider : ConcurrentAuthenticationTokenProvider<TestToken>
+		{
+			private readonly Func<CancellationToken, HttpRequestMessage, Task<TestToken>> _getToken;
+			private readonly Func<CancellationToken, HttpRequestMessage, TestToken, Task> _notifySessionExpired;
+			private readonly Func<CancellationToken, HttpRequestMessage, TestToken, Task<TestToken>> _refreshToken;
+
+			public DelegateAuthenticationTokenProvider(
+				ILoggerFactory loggerFactory,
+				Func<CancellationToken, HttpRequestMessage, Task<TestToken>> getToken,
+				Func<CancellationToken, HttpRequestMessage, TestToken, Task> notifySessionExpired,
+				Func<CancellationToken, HttpRequestMessage, TestToken, Task<TestToken>> refreshToken = null)
+				: base(loggerFactory)
+			{
+				_getToken = getToken;
+				_notifySessionExpired = notifySessionExpired;
+				_refreshToken = refreshToken;
+			}
+
+			public override Task<TestToken> GetToken(CancellationToken ct, HttpRequestMessage request)
+				=> _getToken(ct, request);
+
+			protected override Task NotifySessionExpiredCore(CancellationToken ct, HttpRequestMessage request, TestToken unauthorizedToken)
+				=> _notifySessionExpired(ct, request, unauthorizedToken);
+
+			protected override Task<TestToken> RefreshTokenCore(CancellationToken ct, HttpRequestMessage request, TestToken unauthorizedToken)
+				=> _refreshToken?.Invoke(ct, request, unauthorizedToken);
 		}
 	}
 }

--- a/src/MallardMessageHandlers/AuthenticationToken/ConcurrentAuthenticationTokenProvider.cs
+++ b/src/MallardMessageHandlers/AuthenticationToken/ConcurrentAuthenticationTokenProvider.cs
@@ -109,10 +109,7 @@ namespace MallardMessageHandlers
 			}
 		}
 
-		protected virtual Task NotifySessionExpiredCore(CancellationToken ct, HttpRequestMessage request, TAuthenticationToken unauthorizedToken)
-		{
-			return Task.CompletedTask;
-		}
+		protected abstract Task NotifySessionExpiredCore(CancellationToken ct, HttpRequestMessage request, TAuthenticationToken unauthorizedToken);
 
 		protected abstract Task<TAuthenticationToken> RefreshTokenCore(CancellationToken ct, HttpRequestMessage request, TAuthenticationToken unauthorizedToken);
 	}


### PR DESCRIPTION
GitHub Issue: [#86](https://github.com/nventive/UnoApplicationTemplate/issues/86)

## Proposed Changes
Makes the `ConcurrentAuthenticationTokenProvider<TAuthenticationToken>` an abstract class, allowing deriving classes to implement their own version of the GetToken, NotifySessionExpired and RefreshToken abstract methods, instead of forcing the delegates to be passed into the constructor.

## What is the current behavior?
The current `ConcurrentAuthenticationTokenProvider<TAuthenticationToken>` requires to be constructed with 3 delegates.

## What is the new behavior?
The new `ConcurrentAuthenticationTokenProvider<TAuthenticationToken>` is now abstract and force the implementation to override the methods, making the service a lot more easy to registrer into the DI pipeline.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [x] Associated with an issue

## Breaking changes
Usages of the `ConcurrentAuthenticationTokenProvider<TAuthenticationToken>` will break because it does not allow to be constructed with delegates anymore.

