### PR TITLE
feat: Add support for simple application caching.

### DIFF
--- a/MallardMessageHandlers.sln
+++ b/MallardMessageHandlers.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29905.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32901.215
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MallardMessageHandlers", "src\MallardMessageHandlers\MallardMessageHandlers.csproj", "{8EEF328D-CBC8-45DB-9526-904CC58D2F57}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MallardMessageHandlers.Tests", "src\MallardMessageHandlers.Tests\MallardMessageHandlers.Tests.csproj", "{47E50E30-646E-441B-B2EF-77A33CA4D4B1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MallardMessageHandlers.Refit", "src\MallardMessageHandlers.Refit\MallardMessageHandlers.Refit.csproj", "{3032964A-167E-4DF5-B279-B88E504A282F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +33,14 @@ Global
 		{47E50E30-646E-441B-B2EF-77A33CA4D4B1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{47E50E30-646E-441B-B2EF-77A33CA4D4B1}.Release|NuGet.ActiveCfg = Release|Any CPU
 		{47E50E30-646E-441B-B2EF-77A33CA4D4B1}.Release|NuGet.Build.0 = Release|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Debug|NuGet.ActiveCfg = Debug|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Debug|NuGet.Build.0 = Debug|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Release|NuGet.ActiveCfg = Release|Any CPU
+		{3032964A-167E-4DF5-B279-B88E504A282F}.Release|NuGet.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This repository contains multiple implementations of `DelegatingHandlers` for di
 Here is a list of the `DelegatingHandlers` provided.
 
 - [NetworkExceptionHandler](#NetworkExceptionHandler) : Throws an exception if the HttpRequest fails and there is no network.
+- [SimpleCacheHandler](#SimpleCacheHandler) : Implement simple application caching using instructions from custom HTTP headers.
 - [ExceptionHubHandler](#ExceptionHubHandler) : Reports all exceptions that occur on the pipeline.
 - [ExceptionInterpreterHandler](#ExceptionInterpreterHandler) : Interprets error responses and converts them to exceptions.
 - [AuthenticationTokenHandler](#AuthenticationTokenHandler) : Adds the authentication token to the authorization header.
@@ -87,6 +88,85 @@ private void ConfigureNetworkExceptionHandler(IServiceCollection services)
 
   // The NetworkExceptionHandler must be recreated for all HttpRequests so we add it as transient.
   services.AddTransient<NetworkExceptionHandler>();
+}
+```
+
+### SimpleCacheHandler
+
+The `SimpleCacheHandler` is a `DelegatingHandler` that executes custom caching instructions.
+
+When you use Refit for your endpoints declaration, you can neatly specify caching instructions with attributes.
+
+- You can specify time-to-live at different levels.
+  - On a per-call level (using attributes)
+  - Globally (using default headers)
+- You can support force-refresh scenarios (i.e. don't read the cache, but update it).
+This can be useful for things like pull-to-refresh.
+- You can disable the cache on a per-call level.
+This only makes sense when you define default caching globally.
+
+```csharp
+// (...)
+public static class CacheInstructions
+{
+  public const string DefaultCacheValue = "600"; // 10 minutes
+  public const string ForceRefresh = SimpleCacheHandler.CacheForceRefreshHeaderName;
+  public const string Cache5Minutes = SimpleCacheHandler.CacheTimeToLiveHeaderName + ":300";
+  public const string NoCache = SimpleCacheHandler.CacheDisableHeaderName + ":true";
+}
+
+// (...)
+using static YourNamespace.CacheInstructions;
+
+public interface ISampleEndpoint
+{
+  [Get("/sample")]
+  Task<string> GetSomeInfo([Header(ForceRefresh)] bool forceRefresh = false);
+
+  [Get("/sample")]
+  [Headers(Cache5Minutes)] // You can customize the TTL on a per-call basis.
+  Task<string> GetSomeStuff([Header(ForceRefresh)] bool forceRefresh = false);
+
+  [Get("/sample")]
+  [Headers(NoCache)] // When you have a default TTL, you can bypass it on a per-call basis.
+  Task<string> GetSomeStatus();
+}
+```
+
+Because header attributes works with `string` constants, we recommend you create a static class to declare your caching instructions.
+> 💡 You can even leverage `using static` to have super concise instructions by not repeating the static class name.
+
+Here's how you can configure a default time-to-live for all calls.
+```csharp
+serviceCollection
+  .AddRefitClient<ISampleEndpoint>()
+  .ConfigureHttpClient((client) =>
+  {
+    // You can configure a default time-to-live for all calls.
+    client.DefaultRequestHeaders.Add(SimpleCacheHandler.CacheTimeToLiveHeaderName, "600");
+  });
+```
+
+The `SimpleCacheHandler` has a few dependencies.
+- `ISimpleCacheService` which implements the actual caching of data.
+  - The interface is pretty simple, so you can easily create implementations.
+  - You can also use our `MemorySimpleCacheService` implementation.
+- `ISimpleCacheKeyProvider` which generates the cache keys from the `HttpMessageRequest` objects.
+  - You can use the `SimpleCacheKeyProvider` to create your keys using a custom `Func<HttpRequestMessage,string>`.
+  - You can also use one of our built-in implementations:
+    - `SimpleCacheKeyProvider.FromUriOnly`
+    - `SimpleCacheKeyProvider.FromUriAndAuthorizationHash`
+
+```csharp
+private void ConfigureCacheHandler(IServiceCollection services)
+{
+  // The ISimpleCacheService and ISimpleCacheKeyProvider are shared for all HttpRequests so we add them as singleton.
+  services
+    .AddSingleton<ISimpleCacheService, MemorySimpleCacheService>();
+    .AddSingleton<ISimpleCacheKeyProvider>(CacheKeyProvider.FromUriOnly);
+
+  // The SimpleCacheHandler must be recreated for all HttpRequests so we add it as transient.
+  services.AddTransient<SimpleCacheHandler>();
 }
 ```
 
@@ -232,10 +312,9 @@ private void ConfigureAuthenticationTokenHandler(IServiceCollection services)
 }
 ```
 
-## Changelog
+## Breaking Changes
 
-Please consult the [CHANGELOG](CHANGELOG.md) for more information about version
-history.
+Please consult the [BREAKING_CHANGES.md](BREAKING_CHANGES.md) for more information about breaking changes and version history.
 
 ## License
 
@@ -248,8 +327,3 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on the process for
 contributing to this project.
 
 Be mindful of our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-## Contributors
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/src/MallardMessageHandlers.Refit/MallardMessageHandlers.Refit.csproj
+++ b/src/MallardMessageHandlers.Refit/MallardMessageHandlers.Refit.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<RootNamespace>MallardMessageHandlers</RootNamespace>
+		<Authors>nventive</Authors>
+		<Company>nventive</Company>
+		<AssemblyName>MallardMessageHandlers.Refit</AssemblyName>
+		<PackageId>MallardMessageHandlers.Refit</PackageId>
+		<Description>MallardMessageHandlers.Refit</Description>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>10</LangVersion>
+		<PackageTags>delegatinghandler;oauth;network-status;network;networkexception;authenticationtoken;exceptioninterpreter;exceptionhub;refit</PackageTags>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/nventive/MallardMessageHandlers</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+
+		<!--Needed for Source Link support -->
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Refit" Version="6.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!--Needed for Source Link support -->
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\MallardMessageHandlers\MallardMessageHandlers.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/MallardMessageHandlers.Refit/SimpleCaching/RefitAttributes.cs
+++ b/src/MallardMessageHandlers.Refit/SimpleCaching/RefitAttributes.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Refit;
+
+namespace MallardMessageHandlers.SimpleCaching
+{
+	/// <summary>
+	/// Sets the cache time-to-live for the current call.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Method)]
+	public class TimeToLiveAttribute : HeadersAttribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TimeToLiveAttribute"/> class.
+		/// </summary>
+		/// <param name="totalSeconds">The time-to-live in seconds.</param>
+		public TimeToLiveAttribute(int totalSeconds)
+			: base(SimpleCacheHandler.CacheTimeToLiveHeaderName + ":" + totalSeconds)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TimeToLiveAttribute"/> class.
+		/// </summary>
+		/// <param name="totalMinutes">The time-to-live in minutes.</param>
+		public TimeToLiveAttribute(double totalMinutes)
+			: base(SimpleCacheHandler.CacheTimeToLiveHeaderName + ":" + (int)(totalMinutes * 60))
+		{
+		}
+	}
+
+	/// <summary>
+	/// Bypasses the other simple caching instructions.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Method)]
+	public class NoCacheAttribute : HeadersAttribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="NoCacheAttribute"/> class.
+		/// </summary>
+		public NoCacheAttribute()
+			: base(SimpleCacheHandler.CacheDisableHeaderName + ":true")
+		{
+		}
+	}
+
+	/// <summary>
+	/// Associates the force-refresh simple caching instruction with a boolean parameter.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	public class ForceRefresh : HeaderAttribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ForceRefresh"/> class.
+		/// </summary>
+		public ForceRefresh()
+			: base(SimpleCacheHandler.CacheForceRefreshHeaderName)
+		{
+		}
+	}
+}

--- a/src/MallardMessageHandlers.Tests/CacheHandlerTests.cs
+++ b/src/MallardMessageHandlers.Tests/CacheHandlerTests.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MallardMessageHandlers.SimpleCaching;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace MallardMessageHandlers.Tests
+{
+	public class CacheHandlerTests
+	{
+		private const string DefaultRequestUri = "http://wwww.test.com";
+		private const string Cache5Minutes = SimpleCacheHandler.CacheTimeToLiveHeaderName + ": 300";
+		private const string Cache10Minutes = SimpleCacheHandler.CacheTimeToLiveHeaderName + ": 600";
+		private const string ForceRefresh = SimpleCacheHandler.CacheForceRefreshHeaderName + ": true";
+		private const string DisableCache = SimpleCacheHandler.CacheDisableHeaderName + ": true";
+
+		[Fact]
+		public async Task It_doesnt_invoke_cache_service_when_ttl_header_isnt_present()
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>();
+			var httpClient = GetClient(cacheServiceMock);
+
+			// Act
+			await httpClient.GetAsync(DefaultRequestUri);
+
+			// Assert
+			var x = default(byte[]);
+			cacheServiceMock.Verify(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out x), Times.Never);
+			cacheServiceMock.Verify(s => s.Add(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Never);
+		}
+
+		[Fact]
+		public async Task It_doesnt_invoke_cache_service_when_cache_disable_header_is_present()
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>();
+			var httpClient = GetClient(cacheServiceMock, Cache5Minutes, DisableCache);
+
+			// Act
+			await httpClient.GetAsync(DefaultRequestUri);
+
+			// Assert
+			var x = default(byte[]);
+			cacheServiceMock.Verify(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out x), Times.Never);
+			cacheServiceMock.Verify(s => s.Add(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Never);
+		}
+
+		[Fact]
+		public async Task Cache_service_is_invoked_when_ttl_header_is_present()
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>();
+			var httpClient = GetClient(cacheServiceMock, Cache5Minutes);
+
+			// Act
+			await httpClient.GetAsync(DefaultRequestUri);
+			
+			// Assert
+			var x = default(byte[]);
+			cacheServiceMock.Verify(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out x), Times.Once);
+			cacheServiceMock.Verify(s => s.Add(It.IsAny<string>(), It.IsAny<byte[]>(), It.Is<TimeSpan>(ts => ts.TotalMinutes == 5), It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		[Fact]
+		public async Task Cache_service_is_invoked_most_up_to_date_TTL_value()
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>();
+			// 5 Minutes is the default, 10 minutes is the override. 10 minutes should be used.
+			var httpClient = GetClientWithExtraHeader(cacheServiceMock, insertedHeader: Cache10Minutes, Cache5Minutes);
+
+			// Act
+			await httpClient.GetAsync(DefaultRequestUri);
+
+			// Assert
+			cacheServiceMock.Verify(s => s.Add(It.IsAny<string>(), It.IsAny<byte[]>(), It.Is<TimeSpan>(ts => ts.TotalMinutes == 10), It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		[Fact]
+		public async Task Inner_handler_isnt_called_when_cache_is_active()
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>();
+			var payload = new byte[] { 1, 2, 3 };
+			cacheServiceMock.Setup(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out payload)).ReturnsAsync(true);
+			var innerHandlerWasInvoked = new TaskCompletionSource<bool>();			
+
+			var httpClient = GetClient(cacheServiceMock, innerHandlerWasInvoked, Cache5Minutes);
+
+			// Act
+			var result = await httpClient.GetAsync(DefaultRequestUri);
+
+			// Assert
+			innerHandlerWasInvoked.Task.Status.Should().NotBe(TaskStatus.RanToCompletion);
+			(await result.Content.ReadAsByteArrayAsync()).Should().BeEquivalentTo(payload);
+		}
+
+		[Fact]
+		public async Task InnerHandler_is_called_and_Cache_is_updated_when_ForceRefresh_and_CacheTTL_headers_are_present()
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>();
+			var payload = new byte[] { 1, 2, 3 };
+			cacheServiceMock.Setup(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out payload)).ReturnsAsync(true);
+			var innerHandlerWasInvoked = new TaskCompletionSource<bool>();
+
+			var httpClient = GetClient(cacheServiceMock, innerHandlerWasInvoked, Cache5Minutes, ForceRefresh);
+
+			// Act
+			var result = await httpClient.GetAsync(DefaultRequestUri);
+
+			// Assert
+			innerHandlerWasInvoked.Task.Status.Should().Be(TaskStatus.RanToCompletion);
+			(await result.Content.ReadAsStringAsync()).Should().Be("Hello");
+			cacheServiceMock.Verify(s => s.Add(
+				It.IsAny<string>(),
+				It.Is<byte[]>(bytes => bytes.SequenceEqual(UTF8Encoding.UTF8.GetBytes("Hello"))),
+				It.IsAny<TimeSpan>(),
+				It.IsAny<CancellationToken>()),
+			Times.Once);
+		}
+
+		private static HttpClient GetClient(Mock<ISimpleCacheService> cacheServiceMock, params string[] headers)
+			=> GetClient(cacheServiceMock, new TaskCompletionSource<bool>(), headers);
+
+		private static HttpClient GetClient(Mock<ISimpleCacheService> cacheServiceMock, TaskCompletionSource<bool> innerHandlerWasInvoked, params string[] headers)
+		{
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton(cacheServiceMock.Object)
+				.AddSingleton(SimpleCacheKeyProvider.FromUriOnly)
+				.AddTransient(_ => new TestHandler((r, ct) =>
+				{
+					innerHandlerWasInvoked.TrySetResult(true);
+					return Task.FromResult(new HttpResponseMessage()
+					{
+						Content = new StringContent("Hello")
+					});
+				}))
+				.AddTransient<SimpleCacheHandler>();
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler<SimpleCacheHandler>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+			foreach (var header in headers)
+			{
+				var parts = header.Split(':');
+				var name = parts[0];
+				var value = parts[1];
+				httpClient.DefaultRequestHeaders.Add(name, value);
+			}
+			return httpClient;
+		}
+
+		private static HttpClient GetClientWithExtraHeader(Mock<ISimpleCacheService> cacheServiceMock, string insertedHeader, params string[] headers)
+		{
+			void BuildServices(IServiceCollection s) => s
+				.AddSingleton(cacheServiceMock.Object)
+				.AddSingleton(SimpleCacheKeyProvider.FromUriOnly)
+				.AddTransient(_ => new TestHandler((r, ct) =>
+				{
+					return Task.FromResult(new HttpResponseMessage()
+					{
+						Content = new StringContent("Hello")
+					});
+				}))
+				.AddTransient<SimpleCacheHandler>();
+
+			void BuildHttpClient(IHttpClientBuilder h) => h
+				.AddHttpMessageHandler(() => new HeaderInserterHandler(insertedHeader))
+				.AddHttpMessageHandler<SimpleCacheHandler>()
+				.AddHttpMessageHandler<TestHandler>();
+
+			var httpClient = HttpClientTestsHelper.GetTestHttpClient(BuildServices, BuildHttpClient);
+			foreach (var header in headers)
+			{
+				var parts = header.Split(':');
+				var name = parts[0];
+				var value = parts[1];
+				httpClient.DefaultRequestHeaders.Add(name, value);
+			}
+			return httpClient;
+		}
+
+		private class HeaderInserterHandler : DelegatingHandler
+		{
+			private readonly string _header;
+
+			public HeaderInserterHandler(string header)
+			{
+				_header = header;
+			}
+
+			protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+			{
+				var parts = _header.Split(':');
+				var name = parts[0];
+				var value = parts[1];
+				request.Headers.Add(name, value);
+				return base.SendAsync(request, cancellationToken);
+			}		
+		}
+	}
+}

--- a/src/MallardMessageHandlers.Tests/CachingRefitIntegrationTests.cs
+++ b/src/MallardMessageHandlers.Tests/CachingRefitIntegrationTests.cs
@@ -11,31 +11,22 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Refit;
 using Xunit;
-using static MallardMessageHandlers.Tests.CacheInstructions;
 
 namespace MallardMessageHandlers.Tests
 {
-	public static class CacheInstructions
-	{
-		public const string DefaultCacheValue = "600"; // 10 minutes
-		public const string ForceRefresh = SimpleCacheHandler.CacheForceRefreshHeaderName;
-		public const string Cache5Minutes = SimpleCacheHandler.CacheTimeToLiveHeaderName + ":300";
-		public const string NoCache = SimpleCacheHandler.CacheDisableHeaderName + ":true";
-	}
-
 	public interface ISampleEndpoint
 	{
 		// Default cache is 10 minutes on all methods.
 
 		[Get("/sample")]
-		Task<string> GetSampleDefault(CancellationToken ct, [Header(ForceRefresh)] bool forceRefresh = false);
+		Task<string> GetSampleDefault(CancellationToken ct, [ForceRefresh] bool forceRefresh = false);
 
 		[Get("/sample")]
-		[Headers(Cache5Minutes)] // You can customize the TTL on a per-call basis.
-		Task<string> GetSampleCustomTTL(CancellationToken ct, [Header(ForceRefresh)] bool forceRefresh = false);
+		[TimeToLive(totalMinutes: 5)] // You can customize the TTL on a per-call basis.
+		Task<string> GetSampleCustomTTL(CancellationToken ct, [ForceRefresh] bool forceRefresh = false);
 
 		[Get("/sample")]
-		[Headers(NoCache)] // When you have a default TTL, you can bypass it on a per-call basis.
+		[NoCache] // When you have a default TTL, you can bypass it on a per-call basis.
 		Task<string> GetSampleNoCache(CancellationToken ct);
 	}
 

--- a/src/MallardMessageHandlers.Tests/CachingRefitIntegrationTests.cs
+++ b/src/MallardMessageHandlers.Tests/CachingRefitIntegrationTests.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MallardMessageHandlers.SimpleCaching;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Refit;
+using Xunit;
+using static MallardMessageHandlers.Tests.CacheInstructions;
+
+namespace MallardMessageHandlers.Tests
+{
+	public static class CacheInstructions
+	{
+		public const string DefaultCacheValue = "600"; // 10 minutes
+		public const string ForceRefresh = SimpleCacheHandler.CacheForceRefreshHeaderName;
+		public const string Cache5Minutes = SimpleCacheHandler.CacheTimeToLiveHeaderName + ":300";
+		public const string NoCache = SimpleCacheHandler.CacheDisableHeaderName + ":true";
+	}
+
+	public interface ISampleEndpoint
+	{
+		// Default cache is 10 minutes on all methods.
+
+		[Get("/sample")]
+		Task<string> GetSampleDefault(CancellationToken ct, [Header(ForceRefresh)] bool forceRefresh = false);
+
+		[Get("/sample")]
+		[Headers(Cache5Minutes)] // You can customize the TTL on a per-call basis.
+		Task<string> GetSampleCustomTTL(CancellationToken ct, [Header(ForceRefresh)] bool forceRefresh = false);
+
+		[Get("/sample")]
+		[Headers(NoCache)] // When you have a default TTL, you can bypass it on a per-call basis.
+		Task<string> GetSampleNoCache(CancellationToken ct);
+	}
+
+	public class CachingRefitIntegrationTests
+	{
+		public static IEnumerable<object[]> GetDataFor_GetSampleCache_x1()
+		{
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleDefault(CancellationToken.None)), 10 };
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleCustomTTL(CancellationToken.None)), 5 };
+		}
+
+		[Theory]
+		[MemberData(nameof(GetDataFor_GetSampleCache_x1))]
+		public async Task GetSampleCached_x1(Func<ISampleEndpoint, Task<string>> action, int ttl)
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>(() => new MemorySimpleCacheService());
+			var endpoint = Setup(cacheServiceMock.Object);
+
+			// Act
+			var result = await action(endpoint);
+
+			// Assert
+			res­­ult.Should().Be("1");
+			var x = default(byte[]);
+			cacheServiceMock.Verify(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out x), Times.Once);
+			cacheServiceMock.Verify(s => s.Add(It.IsAny<string>(), It.IsAny<byte[]>(), It.Is<TimeSpan>(ts => ts.TotalMinutes == ttl), It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		public static IEnumerable<object[]> GetDataFor_GetSampleCache_x2()
+		{
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleDefault(CancellationToken.None)) };
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleCustomTTL(CancellationToken.None))};
+		}
+
+		[Theory]
+		[MemberData(nameof(GetDataFor_GetSampleCache_x2))]
+		public async Task GetSampleCached_x2(Func<ISampleEndpoint, Task<string>> action)
+		{
+			// Arrange
+			var endpoint = Setup();
+
+			// Act
+			var result1 = await action(endpoint);
+			var result2 = await action(endpoint);
+
+			// Assert
+			res­­ult1.Should().Be("1");
+			res­­ult2.Should().Be("1");
+		}
+
+		public static IEnumerable<object[]> GetDataFor_GetSampleCached_with_force_refresh_x1()
+		{
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleDefault(CancellationToken.None, forceRefresh: true)), 10 };
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleCustomTTL(CancellationToken.None, forceRefresh: true)), 5 };
+		}
+
+		[Theory]
+		[MemberData(nameof(GetDataFor_GetSampleCached_with_force_refresh_x1))]
+		public async Task GetSampleCached_with_force_refresh_x1(Func<ISampleEndpoint, Task<string>> action, int ttl)
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>(() => new MemorySimpleCacheService());
+			var endpoint = Setup(cacheServiceMock.Object);
+
+			// Act
+			var result1 = await action(endpoint);
+
+			// Assert
+			var x = default(byte[]);
+			cacheServiceMock.Verify(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out x), Times.Never);
+			cacheServiceMock.Verify(s => s.Add(It.IsAny<string>(), It.IsAny<byte[]>(), It.Is<TimeSpan>(ts => ts.TotalMinutes == ttl), It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		public static IEnumerable<object[]> GetDataFor_GetSampleCached_with_force_refresh_x2()
+		{
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleDefault(CancellationToken.None, forceRefresh: true)) };
+			yield return new object[] { (Func<ISampleEndpoint, Task<string>>)(endpoint => endpoint.GetSampleCustomTTL(CancellationToken.None, forceRefresh: true)) };
+		}
+
+		[Theory]
+		[MemberData(nameof(GetDataFor_GetSampleCached_with_force_refresh_x2))]
+		public async Task GetSampleCached_with_force_refresh_x2(Func<ISampleEndpoint, Task<string>> action)
+		{
+			// Arrange
+			var endpoint = Setup();
+
+			// Act
+			var result1 = await action(endpoint);
+			var result2 = await action(endpoint);
+
+			// Assert
+			res­­ult1.Should().Be("1");
+			res­­ult2.Should().Be("2");
+		}
+
+		[Fact]
+		public async Task GetSampleNoCache_x1()
+		{
+			// Arrange
+			var cacheServiceMock = new Mock<ISimpleCacheService>(() => new MemorySimpleCacheService());
+			var endpoint = Setup(cacheServiceMock.Object);
+
+			// Act
+			var result = await endpoint.GetSampleNoCache(CancellationToken.None);
+
+			// Assert
+			res­­ult.Should().Be("1");
+			var x = default(byte[]);
+			cacheServiceMock.Verify(s => s.TryGet(It.IsAny<string>(), It.IsAny<CancellationToken>(), out x), Times.Never);
+			cacheServiceMock.Verify(s => s.Add(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Never);
+		}
+
+		[Fact]
+		public async Task GetSampleNoCache_x2()
+		{
+			// Arrange
+			var endpoint = Setup();
+
+			// Act
+			var result1 = await endpoint.GetSampleNoCache(CancellationToken.None);
+			var result2 = await endpoint.GetSampleNoCache(CancellationToken.None);
+
+			// Assert
+			res­­ult1.Should().Be("1");
+			res­­ult2.Should().Be("2");
+		}
+
+		private ISampleEndpoint Setup(ISimpleCacheService cacheService = null)
+		{
+			int callCount = 0;
+			var serviceCollection = new ServiceCollection()
+				.AddSingleton<ISimpleCacheService>(cacheService ?? new MemorySimpleCacheService())
+				.AddSingleton(SimpleCacheKeyProvider.FromUriAndAuthorizationHash)
+				.AddTransient(_ => new TestHandler((request, ct) =>
+				{
+					var response = new HttpResponseMessage()
+					{
+						Content = new StringContent($"{++callCount}")
+					};
+					return Task.FromResult(response);
+				}))
+				.AddTransient<SimpleCacheHandler>();
+
+			serviceCollection
+				.AddRefitClient<ISampleEndpoint>()
+				.ConfigureHttpClient((client) =>
+				{
+					client.BaseAddress = new Uri("http://localhost");
+					client.DefaultRequestHeaders.Add("Authorization", "Bearer 123");
+					client.DefaultRequestHeaders.Add(SimpleCacheHandler.CacheTimeToLiveHeaderName, "600");
+				})
+				.ConfigurePrimaryHttpMessageHandler<TestHandler>()
+				.AddHttpMessageHandler<SimpleCacheHandler>();
+
+			var serviceProvider = serviceCollection.BuildServiceProvider();
+			return serviceProvider.GetRequiredService<ISampleEndpoint>();
+		}
+	}
+}

--- a/src/MallardMessageHandlers.Tests/MallardMessageHandlers.Tests.csproj
+++ b/src/MallardMessageHandlers.Tests/MallardMessageHandlers.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
 		<PackageReference Include="FluentAssertions" Version="5.9.0" />
+		<PackageReference Include="Refit.HttpClientFactory" Version="5.0.15" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />

--- a/src/MallardMessageHandlers.Tests/MallardMessageHandlers.Tests.csproj
+++ b/src/MallardMessageHandlers.Tests/MallardMessageHandlers.Tests.csproj
@@ -1,25 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
 		<AssemblyName>MallardMessageHandlers.Tests</AssemblyName>
     <RootNamespace>MallardMessageHandlers.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-		<PackageReference Include="FluentAssertions" Version="5.9.0" />
-		<PackageReference Include="Refit.HttpClientFactory" Version="5.0.15" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
-		<PackageReference Include="System.Text.Json" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+		<PackageReference Include="FluentAssertions" Version="6.7.0" />
+		<PackageReference Include="Refit" Version="6.3.2" />
+		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+		<PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MallardMessageHandlers.Refit\MallardMessageHandlers.Refit.csproj" />
     <ProjectReference Include="..\MallardMessageHandlers\MallardMessageHandlers.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MallardMessageHandlers.Tests/MemoryCacheServiceTests.cs
+++ b/src/MallardMessageHandlers.Tests/MemoryCacheServiceTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MallardMessageHandlers.SimpleCaching;
+using Moq;
+using Xunit;
+
+namespace MallardMessageHandlers.Tests
+{
+	public class MemoryCacheServiceTests
+	{
+		private readonly CancellationToken _ctNone = CancellationToken.None;
+
+		[Fact]
+		public async Task TryGet_returns_non_expired_payloads()
+		{
+			// Arrange
+			var cache = new MemorySimpleCacheService();
+			var payload = new byte[0];
+
+			// Act
+			await cache.Add("key", payload, TimeSpan.FromMinutes(1000), _ctNone);
+
+			// Assert
+			(await cache.TryGet("key", _ctNone, out var content)).Should().BeTrue();
+			content.Should().BeSameAs(payload);
+		}
+
+		[Fact]
+		public async Task TryGet_doesnt_return_expired_payloads()
+		{
+			// Arrange
+			var cache = new MemorySimpleCacheService();
+			var payload = new byte[0];
+			
+			// Act
+			await cache.Add("key", payload, TimeSpan.FromMinutes(0), _ctNone);
+
+			// Assert
+			(await cache.TryGet("key", _ctNone, out var content)).Should().BeFalse();
+			content.Should().BeNull();
+		}
+
+		[Fact]
+		public async Task Clear_removes_previous_items()
+		{
+			// Arrange
+			var cache = new MemorySimpleCacheService();
+			var payload = new byte[0];
+
+			// Act
+			await cache.Add("key", payload, TimeSpan.FromMinutes(1000), _ctNone);
+			await cache.Clear(_ctNone);
+
+			// Assert
+			(await cache.TryGet("key", _ctNone, out var content)).Should().BeFalse();
+			content.Should().BeNull();
+		}
+
+		[Fact]
+		public async Task Add_preserves_the_latest_value()
+		{
+			// Arrange
+			var cache = new MemorySimpleCacheService();
+			var payload = new byte[0];
+			var payload2 = new byte[1];
+
+			// Act
+			await cache.Add("key", payload, TimeSpan.FromMinutes(1000), _ctNone);
+			await cache.Add("key", payload2, TimeSpan.FromMinutes(1000), _ctNone);
+
+			// Assert
+			(await cache.TryGet("key", _ctNone, out var content)).Should().BeTrue();
+			content.Should().BeSameAs(payload2);
+		}
+		
+	}
+}

--- a/src/MallardMessageHandlers/IsExternalInit.cs
+++ b/src/MallardMessageHandlers/IsExternalInit.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// This allows the usage of record even though this is a .NET Standard 2.0 project.
+/// </summary>
+internal static class IsExternalInit
+{
+}

--- a/src/MallardMessageHandlers/MallardMessageHandlers.csproj
+++ b/src/MallardMessageHandlers/MallardMessageHandlers.csproj
@@ -8,6 +8,7 @@
 		<PackageId>MallardMessageHandlers</PackageId>
 		<Description>MallardMessageHandlers</Description>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>10</LangVersion>
 		<PackageTags>delegatinghandler;oauth;network-status;network;networkexception;authenticationtoken;exceptioninterpreter;exceptionhub</PackageTags>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/nventive/MallardMessageHandlers</PackageProjectUrl>

--- a/src/MallardMessageHandlers/SimpleCaching/ISimpleCacheKeyProvider.cs
+++ b/src/MallardMessageHandlers/SimpleCaching/ISimpleCacheKeyProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace MallardMessageHandlers.SimpleCaching;
+
+/// <summary>
+/// Provides a way to get a cache key from a <see cref="HttpRequestMessage"/>.
+/// This is used by <see cref="SimpleCacheHandler"/>.
+/// </summary>
+public interface ISimpleCacheKeyProvider
+{
+	/// <summary>
+	/// Gets the cache key for the <paramref name="request"/>.
+	/// </summary>
+	/// <param name="request">The request.</param>
+	/// <returns>A cache key.</returns>
+	string GetKey(HttpRequestMessage request);
+}

--- a/src/MallardMessageHandlers/SimpleCaching/ISimpleCacheService.cs
+++ b/src/MallardMessageHandlers/SimpleCaching/ISimpleCacheService.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MallardMessageHandlers.SimpleCaching;
+
+/// <summary>
+/// Represents a simple cache service allowing to cache data using a string key and a time-to-live.
+/// </summary>
+public interface ISimpleCacheService
+{
+	/// <summary>
+	/// Adds a payload to the cache with the specified key and expiration.
+	/// </summary>
+	/// <param name="key">The cache key.</param>
+	/// <param name="payload">The data to cache.</param>
+	/// <param name="timeToLive">The duration for which the cache entry should stay retrievable.</param>
+	/// <param name="ct">The cancellation token.</param>
+	Task Add(string key, byte[] payload, TimeSpan timeToLive, CancellationToken ct);
+
+	/// <summary>
+	/// Gets the payload associated with the specified key, if available.
+	/// </summary>
+	/// <param name="key">The cache key.</param>
+	/// <param name="ct">The cancellation token.</param>
+	/// <param name="payload">The cache content for that key.</param>
+	/// <returns>The cached payload or null when the key isn't found or when the payload is expired.</returns>
+	Task<bool> TryGet(string key, CancellationToken ct, out byte[] payload);
+
+	/// <summary>
+	/// Clears all cache data.
+	/// </summary>
+	/// <param name="ct">The cancellation token.</param>
+	Task Clear(CancellationToken ct);
+}

--- a/src/MallardMessageHandlers/SimpleCaching/MemorySimpleCacheService.cs
+++ b/src/MallardMessageHandlers/SimpleCaching/MemorySimpleCacheService.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MallardMessageHandlers.SimpleCaching;
+
+/// <summary>
+/// This is a simple implementation of <see cref="ISimpleCacheService"/> that stores payloads in a <see cref="ConcurrentDictionary{TKey, TValue}"/>
+/// and uses <see cref="DateTimeOffset.Now"/> for time reference.
+/// </summary>
+[Preserve(AllMembers = true)]
+public sealed class MemorySimpleCacheService : ISimpleCacheService
+{
+	private static readonly Task<bool> _trueResult = Task.FromResult(true);
+	private static readonly Task<bool> _falseResult = Task.FromResult(false);
+	private readonly ConcurrentDictionary<string, CacheEntry> _data = new ConcurrentDictionary<string, CacheEntry>();
+
+	/// <inheritdoc />
+	public Task Add(string key, byte[] payload, TimeSpan timeToLive, CancellationToken ct)
+	{
+		if (ct.IsCancellationRequested)
+		{
+			return Task.CompletedTask;
+		}
+
+		var entry = new CacheEntry(payload, DateTimeOffset.Now + timeToLive);
+		_data[key] = entry;
+
+		return Task.CompletedTask;
+	}
+
+	/// <inheritdoc />
+	public Task Clear(CancellationToken ct)
+	{
+		if (ct.IsCancellationRequested)
+		{
+			return Task.CompletedTask;
+		}
+
+		_data.Clear();
+		return Task.CompletedTask;
+	}
+
+	/// <inheritdoc />
+	public Task<bool> TryGet(string key, CancellationToken ct, out byte[] payload)
+	{
+		if (ct.IsCancellationRequested)
+		{
+			payload = null;
+			return _falseResult;
+		}
+
+		if (_data.TryGetValue(key, out var entry))
+		{
+			if (entry.Expiration > DateTimeOffset.Now)
+			{
+				payload = entry.Payload;
+				return _trueResult;
+			}
+			else
+			{
+				_data.TryRemove(key, out _);
+			}
+		}
+
+		payload = null;
+		return _falseResult;
+	}
+
+	private record CacheEntry(byte[] Payload, DateTimeOffset Expiration) { }
+}

--- a/src/MallardMessageHandlers/SimpleCaching/SimpleCacheHandler.cs
+++ b/src/MallardMessageHandlers/SimpleCaching/SimpleCacheHandler.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MallardMessageHandlers.SimpleCaching;
+
+[Preserve(AllMembers = true)]
+public sealed class SimpleCacheHandler : DelegatingHandler
+{
+	/// <summary>
+	/// The HTTP header name for the Time-To-Live caching instruction.
+	/// The header value needs to be an integer representing the total seconds of the time-to-live.
+	/// <code>
+	/// // Example:
+	/// "X-Mallard-SimpleCache-TTL:600" // Sets the time-to-live to 10 minutes (600 seconds).
+	/// </code>
+	/// </summary>
+	public const string CacheTimeToLiveHeaderName = "X-Mallard-SimpleCache-TTL";
+
+	/// <summary>
+	/// The HTTP header name for the Force-Refresh caching instruction.
+	/// The header value needs to be a boolean representing whether the force-refresh instruction is to be applied.
+	/// </summary>
+	public const string CacheForceRefreshHeaderName = "X-Mallard-SimpleCache-ForceRefresh";
+
+	/// <summary>
+	/// The HTTP header name for the Disable caching instruction.
+	/// The header value needs to be a boolean representing whether the disable instruction is to be applied.
+	/// This instruction takes precedence over all others.
+	/// </summary>
+	public const string CacheDisableHeaderName = "X-Mallard-SimpleCache-Disable";
+
+	private readonly ISimpleCacheService _cacheService;
+	private readonly ISimpleCacheKeyProvider _cacheKeyProvider;
+
+	/// <summary>
+	/// Initializes a new instance of <see cref="SimpleCacheHandler"/>.
+	/// </summary>
+	/// <param name="cacheService">The cache service to use to store payloads.</param>
+	/// <param name="cacheKeyProvider">The <see cref="ISimpleCacheKeyProvider"/> to use to generate the cache keys.</param>
+	public SimpleCacheHandler(ISimpleCacheService cacheService, ISimpleCacheKeyProvider cacheKeyProvider)
+	{
+		_cacheService = cacheService;
+		_cacheKeyProvider = cacheKeyProvider;
+	}
+
+	/// <inheritdoc />
+	protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		if (request.Method != HttpMethod.Get)
+		{
+			return await base.SendAsync(request, cancellationToken);
+		}
+
+		// The Cache-Disable header overrides all other cache instructions and forces normal execution.
+		if (ExtractIsCacheDisabled(request))
+		{
+			return await base.SendAsync(request, cancellationToken);
+		}
+
+		var cacheKey = _cacheKeyProvider.GetKey(request);
+		var isForceRefresh = ExtractIsForceRefresh(request);
+		var isCacheable = ExtractIsCacheEnabled(request, out var timeToLive);
+		var cachedPayload = default(byte[]);
+
+		if (isForceRefresh || !isCacheable || isCacheable && !await _cacheService.TryGet(cacheKey, cancellationToken, out cachedPayload))
+		{
+			var response = await base.SendAsync(request, cancellationToken);
+
+			if (isCacheable && response.IsSuccessStatusCode && !cancellationToken.IsCancellationRequested)
+			{
+				await _cacheService.Add(cacheKey, await response.Content.ReadAsByteArrayAsync(), timeToLive, cancellationToken);
+			}
+
+			return response;
+		}
+		else
+		{
+			var cacheResponse = new HttpResponseMessage();
+			cacheResponse.Content = new ByteArrayContent(cachedPayload);
+			return cacheResponse;
+		}
+	}
+
+	/// <summary>
+	/// Gets whether the request is a force refresh request and removes the force refresh header.
+	/// </summary>
+	/// <param name="request">The request.</param>
+	/// <returns>Whether <paramref name="request"/> requires a refresh.</returns>
+	private bool ExtractIsForceRefresh(HttpRequestMessage request)
+	{
+		var headerName = CacheForceRefreshHeaderName;
+		if (request.Headers.TryGetValues(headerName, out var forceRefreshValues))
+		{
+			request.Headers.Remove(headerName);
+			var rawForceRefresh = forceRefreshValues.LastOrDefault();
+			return bool.Parse(rawForceRefresh);
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Gets whether the request has caching disabled.
+	/// </summary>
+	/// <param name="request">The request.</param>
+	/// <returns>Whether <paramref name="request"/> doesn't have caching.</returns>
+	private bool ExtractIsCacheDisabled(HttpRequestMessage request)
+	{
+		var headerName = CacheDisableHeaderName;
+		if (request.Headers.TryGetValues(headerName, out var disableCacheValues))
+		{
+			request.Headers.Remove(headerName);
+			request.Headers.Remove(CacheForceRefreshHeaderName);
+			request.Headers.Remove(CacheTimeToLiveHeaderName);
+			var rawDisableCache = disableCacheValues.LastOrDefault();
+			return bool.Parse(rawDisableCache);
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Gets whether the request is a force refresh request and removes the force refresh header.
+	/// </summary>
+	/// <param name="request">The request.</param>
+	/// <param name="timeToLive">The time to live of result of this request, when the cache is enable.</param>
+	/// <returns>Whether <paramref name="request"/> requires a refresh.</returns>
+	private bool ExtractIsCacheEnabled(HttpRequestMessage request, out TimeSpan timeToLive)
+	{
+		var headerName = CacheTimeToLiveHeaderName;
+		if (request.Headers.TryGetValues(headerName, out var timeToLiveValues))
+		{
+			request.Headers.Remove(headerName);
+			// We use LastOrDefault to use the lastest value. (The can be a default value and an override value).
+			var rawTimeToLive = timeToLiveValues.LastOrDefault();
+			timeToLive = TimeSpan.FromSeconds(int.Parse(rawTimeToLive));
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/MallardMessageHandlers/SimpleCaching/SimpleCacheKeyProvider.cs
+++ b/src/MallardMessageHandlers/SimpleCaching/SimpleCacheKeyProvider.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace MallardMessageHandlers.SimpleCaching;
+
+/// <summary>
+/// This class provides a default implementation of <see cref="ISimpleCacheKeyProvider"/> and common static instances.
+/// </summary>
+public sealed class SimpleCacheKeyProvider : ISimpleCacheKeyProvider
+{
+	/// <summary>
+	/// Gets a <see cref="ISimpleCacheKeyProvider"/> that generates a cache key using only the Uri of the <see cref="HttpRequestMessage"/>.
+	/// </summary>
+	public static ISimpleCacheKeyProvider FromUriOnly { get; } = new SimpleCacheKeyProvider(GetKeyFromUriOnly);
+
+	/// <summary>
+	/// Gets a <see cref="ISimpleCacheKeyProvider"/> that generates a cache key using the Uri of the <see cref="HttpRequestMessage"/> and a hash (SHA256) of the Authorization header value.
+	/// </summary>
+	public static ISimpleCacheKeyProvider FromUriAndAuthorizationHash { get; } = new UriAndAuthorizationHashCacheKeyProvider();
+
+	private static string GetKeyFromUriOnly(HttpRequestMessage httpRequestMessage)
+		=> httpRequestMessage.RequestUri.ToString();
+
+	private readonly Func<HttpRequestMessage, string> _function;
+
+	/// <summary>
+	/// Initializes a new instances of <see cref="SimpleCacheKeyProvider"/>.
+	/// </summary>
+	/// <param name="function">The function that gets the cache key.</param>
+	public SimpleCacheKeyProvider(Func<HttpRequestMessage, string> function)
+	{
+		_function = function;
+	}
+
+	/// <inheritdoc />
+	public string GetKey(HttpRequestMessage request) => _function(request);
+}
+
+/// <summary>
+/// This implementation of <see cref="ISimpleCacheKeyProvider"/> generates a cache key using the Uri of the <see cref="HttpRequestMessage"/> and a hash of the Authorization header value.
+/// </summary>
+public sealed class UriAndAuthorizationHashCacheKeyProvider : ISimpleCacheKeyProvider, IDisposable
+{
+	private readonly System.Security.Cryptography.SHA256Managed _sha = new();
+
+	/// <inheritdoc/>
+	public string GetKey(HttpRequestMessage httpRequestMessage)
+	{
+		var sb = new StringBuilder();
+		sb.Append(httpRequestMessage.RequestUri);
+		var authorizationValue = httpRequestMessage.Headers.Authorization.Parameter;
+		if (!string.IsNullOrEmpty(authorizationValue))
+		{
+			var textData = Encoding.UTF8.GetBytes(authorizationValue);
+			var hashBytes = _sha.ComputeHash(textData);
+			var hash = BitConverter.ToString(hashBytes).Replace("-", string.Empty);
+			sb.Append(hash);
+		}
+		return sb.ToString();
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		_sha.Dispose();
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description
- Add simple caching recipes based on http headers and delegating handlers.
- Add a new `MallardMessageHandlers.Refit` package that exposes new Refit attributes for simple caching instructions.
- Fix Readme: Replace Changelog with Breaking Changes.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [x] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->
