### PR TITLE
feat: enable deterministic build

### DIFF
--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -47,8 +47,10 @@
     restoreNugetPackages: false
     logProjectEvents: false
     createLogFile: false
-    msbuildArguments: /p:PackageVersion=$(GitVersion.SemVer) # Set the version of the packages, will have no effect on application projects (Heads).
-
+    msbuildArguments: >  # Set the version of the packages, will have no effect on application projects (Heads).
+      /p:PackageVersion=$(GitVersion.SemVer)
+      /p:ContinousIntegrationBuild=true
+      
 - script: dotnet test --no-build --configuration $(ApplicationConfiguration) --logger trx --collect "Code coverage"
   displayName: 'Run tests'
   condition: and(succeeded(), eq(variables['ApplicationPlatform'], 'NuGet'))


### PR DESCRIPTION
## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Feature

- Enabled flag for `ContinuousIntegrationBuild `  . More info [here](https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/#deterministic-builds)

## What is the current behavior?

- Deterministic build not correctly set due to missing msbuild arguments  `ContinuousIntegrationBuild `


## What is the new behavior?

-  Deterministic build is now correctly enabled on CI builds


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

